### PR TITLE
Fix: Replace alert with inline error in Tattoo Simulator

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -23,6 +23,7 @@ const App = () => {
   const [selectedBodyPart, setSelectedBodyPart] = useState('brazo');
   const [designImage, setDesignImage] = useState(null);
   const [designUrl, setDesignUrl] = useState('');
+  const [designUrlError, setDesignUrlError] = useState('');
   const [tattooSize, setTattooSize] = useState(100);
   const constraintsRef = useRef(null);
   const draggableRef = useRef(null);
@@ -670,7 +671,12 @@ const App = () => {
                       <input
                         type="text"
                         value={designUrl}
-                        onChange={(e) => setDesignUrl(e.target.value)}
+                        onChange={(e) => {
+                          setDesignUrl(e.target.value);
+                          if (designUrlError) {
+                            setDesignUrlError('');
+                          }
+                        }}
                         placeholder="O pega una URL"
                         className="w-full px-3 py-2 bg-background/50 border border-background/50 rounded-lg focus:ring-1 focus:ring-primary-accent text-sm"
                       />
@@ -681,8 +687,9 @@ const App = () => {
                           };
                           if (isValidImageUrl(designUrl)) {
                             setDesignImage(designUrl);
+                            setDesignUrlError('');
                           } else {
-                            alert('URL inválida. Por favor, introduce una URL de una imagen válida (jpg, jpeg, png, gif, webp).');
+                            setDesignUrlError('URL inválida. Por favor, introduce una URL de una imagen válida (jpg, jpeg, png, gif, webp).');
                           }
                         }}
                         className="p-2 bg-primary-accent rounded-lg text-background hover:bg-opacity-80"
@@ -691,6 +698,7 @@ const App = () => {
                         <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 10V3L4 14h7v7l9-11h-7z" /></svg>
                       </button>
                     </div>
+                    {designUrlError && <p className="text-red-500 text-sm mt-2">{designUrlError}</p>}
                   </div>
                 </div>
                 <div>

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -92,3 +92,20 @@ test('should not update the design image with an invalid URL', async () => {
   const designImage = screen.queryByAltText(/Diseño de tatuaje para simular/i);
   expect(designImage).not.toBeInTheDocument();
 });
+
+test('should display an error message for an invalid image URL', async () => {
+  render(<App />);
+
+  const urlInput = screen.getByPlaceholderText(/O pega una URL/i);
+  const loadButton = screen.getByRole('button', { name: /Cargar diseño desde URL/i });
+
+  // Simulate user input with an invalid URL
+  fireEvent.change(urlInput, { target: { value: 'not-a-valid-url' } });
+
+  // Click the load button
+  fireEvent.click(loadButton);
+
+  // Check that an error message is displayed. This will fail before the fix.
+  const errorMessage = await screen.findByText(/URL inválida/i);
+  expect(errorMessage).toBeInTheDocument();
+});


### PR DESCRIPTION
Replaces the browser's `alert()` with a state-driven inline error message in the Tattoo Simulator feature.

Previously, providing an invalid image URL would trigger a native `alert()`, which is disruptive to the user experience and untestable in a jsdom environment without mocking.

This change introduces a new state variable to manage the URL validation error. The error is now displayed as a user-friendly message directly within the component, improving both the UI and the testability of the feature.

A new test case has been added to verify that the error message is correctly displayed when an invalid URL is provided.